### PR TITLE
Workaround SabreDAV's "funny" behaviour for contact sync

### DIFF
--- a/lib/Net/CardDAVTalk.pm
+++ b/lib/Net/CardDAVTalk.pm
@@ -654,6 +654,12 @@ sub SyncContactLinks {
         # Missing properties return 404 status response, ignore
 
       }
+      elsif ($Status =~ m/ 418 /) {
+        # Sabredav thinks it's funny to return 418 for missing entries.
+        # What they mean here is that this contact has since been removed.
+        # See https://github.com/sabre-io/dav/pull/734
+        push @Removed, $href;
+      }
       else {
         warn "ODD STATUS";
         push @Errors, "Odd status in propstat response $href: $Status";


### PR DESCRIPTION
SabreDAV team [thought it'd be funnier](https://github.com/sabre-io/dav/pull/734) to return `I'm a teapot` rather than a good old `Not found` when propstat-ing since removed contacts. I don't disagree, but it did confuse CardDAVTalk for sure :)

This worksaround the problem and interprets their response correctly. Not sure if you want to merge it in this state, maybe there is a more fitting solution to this.